### PR TITLE
CI: Fix release trigger event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release new python-deploy version
 
 on:
-  push:
-    tags: 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   release_pypi:


### PR DESCRIPTION
AFAIK `github.event.release.tag_name` works for release events, not push tag events